### PR TITLE
Add guidelines for CSS short descriptions

### DIFF
--- a/CSS-short-description-guidelines.md
+++ b/CSS-short-description-guidelines.md
@@ -1,0 +1,18 @@
+# Guidelines for CSS short descriptions
+
+Short descriptions will be consistent with the following guidelines:
+
+* Short descriptions may be formatted with only the HTML tags `<a>`, `<code>`, `<em>`, and `<strong>`.
+* `<a>` tags may use only on the `href` attribute pointing to absolute URLs.
+* Short descriptions must not exceed 180 displayed (rendered) characters. Optimally, they should be 100 to 120 characters.
+* The first sentence should be no more than 150 displayed characters.
+* Short descriptions text should stand alone (e.g., it should not refer to text, images, or other content outside the short description).
+* Short descriptions must not mention support or standards status.
+* Short descriptions should mention relevant keywords and topic areas (e.g., a property that affects layout should mention the word "layout" and perhaps the model in which it applies, such as "grid").
+* Short descriptions should avoid the use of words like "specifies", "defines", or "determines" when the word "sets" is just as good and results in no loss of meaning.
+
+* Short descriptions should describe, in the active voice, what a CSS property does. "The `some-property` CSS property sets the …" is a good pattern for starting a short description.
+* Short descriptions should contain the name of the CSS property and the phrase "CSS property".
+* Short descriptions should use the word "shorthand" if the property is a shorthand.
+
+See https://github.com/mdn/data/issues/261 for details on how these guidelines were created.

--- a/writing-short-descriptions.md
+++ b/writing-short-descriptions.md
@@ -1,4 +1,4 @@
-# Guidelines for CSS short descriptions
+# Writing short descriptions
 
 Short descriptions will be consistent with the following guidelines:
 


### PR DESCRIPTION
This copies the guidelines from https://github.com/mdn/data/wiki/CSS-property-short-descriptions#format-length-and-content into a separate doc, to make it easier to reference and help us clean up the old stuff in mdn/data.