### PR TITLE
Add initial JSON entries

### DIFF
--- a/descriptions/css/properties/animation-fill-mode.json
+++ b/descriptions/css/properties/animation-fill-mode.json
@@ -1,0 +1,3 @@
+{
+  "animation-fill-mode": "The <strong><code>animation-fill-mode</code></strong> <a href='https://developer.mozilla.org/en/CSS'>CSS</a> property sets how a CSS animation applies styles to its target before and after its execution."
+}

--- a/descriptions/css/properties/animation-fill-mode.json
+++ b/descriptions/css/properties/animation-fill-mode.json
@@ -1,3 +1,9 @@
 {
-  "animation-fill-mode": "The <strong><code>animation-fill-mode</code></strong> <a href='https://developer.mozilla.org/en/CSS'>CSS</a> property sets how a CSS animation applies styles to its target before and after its execution."
+  "css": {
+    "properties": {
+      "animation-fill-mode": {
+        "__short_description": "The <strong><code>animation-fill-mode</code></strong> <a href='https://developer.mozilla.org/en/CSS'>CSS</a> property sets how a CSS animation applies styles to its target before and after its execution."
+      }
+    }
+  }
 }

--- a/descriptions/css/properties/columns.json
+++ b/descriptions/css/properties/columns.json
@@ -1,0 +1,3 @@
+{
+  "columns": "The <strong><code>columns</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the column width and column count of an element."
+}

--- a/descriptions/css/properties/columns.json
+++ b/descriptions/css/properties/columns.json
@@ -1,3 +1,9 @@
 {
-  "columns": "The <strong><code>columns</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the column width and column count of an element."
+  "css": {
+    "properties": {
+      "columns": {
+        "__short_description": "The <strong><code>columns</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the column width and column count of an element."
+      }
+    }
+  }
 }

--- a/descriptions/css/properties/font-family.json
+++ b/descriptions/css/properties/font-family.json
@@ -1,0 +1,3 @@
+{
+  "font-family": "The <strong><code>font-family</code></strong> CSS property specifies a prioritized list of one or more font family names and/or generic family names for the selected element."
+}

--- a/descriptions/css/properties/font-family.json
+++ b/descriptions/css/properties/font-family.json
@@ -1,3 +1,9 @@
 {
-  "font-family": "The <strong><code>font-family</code></strong> CSS property specifies a prioritized list of one or more font family names and/or generic family names for the selected element."
+  "css": {
+    "properties": {
+      "font-family": {
+        "__short_description": "The <strong><code>font-family</code></strong> CSS property specifies a prioritized list of one or more font family names and/or generic family names for the selected element."
+      }
+    }
+  }
 }

--- a/descriptions/css/properties/initial-letter.json
+++ b/descriptions/css/properties/initial-letter.json
@@ -1,3 +1,9 @@
 {
-  "initial-letter": "The <code>initial-letter</code> CSS property sets styling for dropped, raised, and sunken initial letters."
+  "css": {
+    "properties": {
+      "initial-letter": {
+        "__short_description": "The <code>initial-letter</code> CSS property sets styling for dropped, raised, and sunken initial letters."
+      }
+    }
+  }
 }

--- a/descriptions/css/properties/initial-letter.json
+++ b/descriptions/css/properties/initial-letter.json
@@ -1,0 +1,3 @@
+{
+  "initial-letter": "The <code>initial-letter</code> CSS property sets styling for dropped, raised, and sunken initial letters."
+}

--- a/descriptions/css/properties/justify-self.json
+++ b/descriptions/css/properties/justify-self.json
@@ -1,3 +1,9 @@
 {
-  "justify-self": "The <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> <strong><code>justify-self</code></strong> property set the way a box is justified inside its alignment container along the appropriate axis."
+  "css": {
+    "properties": {
+      "justify-self": {
+        "__short_description": "The <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> <strong><code>justify-self</code></strong> property set the way a box is justified inside its alignment container along the appropriate axis."
+      }
+    }
+  }
 }

--- a/descriptions/css/properties/justify-self.json
+++ b/descriptions/css/properties/justify-self.json
@@ -1,0 +1,3 @@
+{
+  "justify-self": "The <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> <strong><code>justify-self</code></strong> property set the way a box is justified inside its alignment container along the appropriate axis."
+}

--- a/descriptions/css/properties/list-style-type.json
+++ b/descriptions/css/properties/list-style-type.json
@@ -1,3 +1,9 @@
 {
-  "list-style-type": "The<strong> <code>list-style-type</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the marker (such as a disc, character, or custom counter style) of a list item element."
+  "css": {
+    "properties": {
+      "list-style-type": {
+        "__short_description": "The<strong> <code>list-style-type</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the marker (such as a disc, character, or custom counter style) of a list item element."
+      }
+    }
+  }
 }

--- a/descriptions/css/properties/list-style-type.json
+++ b/descriptions/css/properties/list-style-type.json
@@ -1,0 +1,3 @@
+{
+  "list-style-type": "The<strong> <code>list-style-type</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the marker (such as a disc, character, or custom counter style) of a list item element."
+}

--- a/descriptions/css/properties/margin-top.json
+++ b/descriptions/css/properties/margin-top.json
@@ -1,3 +1,9 @@
 {
-  "margin-top": "The <strong><code>margin-top</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model'>margin area</a> on the top of an element. A positive value places it farther from its neighbors, while a negative value places it closer."
+  "css": {
+    "properties": {
+      "margin-top": {
+        "__short_description": "The <strong><code>margin-top</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model'>margin area</a> on the top of an element. A positive value places it farther from its neighbors, while a negative value places it closer."
+      }
+    }
+  }
 }

--- a/descriptions/css/properties/margin-top.json
+++ b/descriptions/css/properties/margin-top.json
@@ -1,0 +1,3 @@
+{
+  "margin-top": "The <strong><code>margin-top</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model'>margin area</a> on the top of an element. A positive value places it farther from its neighbors, while a negative value places it closer."
+}

--- a/descriptions/css/properties/opacity.json
+++ b/descriptions/css/properties/opacity.json
@@ -1,3 +1,9 @@
 {
-  "opacity": "The <strong><code>opacity</code></strong> CSS property sets the transparency of an element or the degree to which content behind an element is visible."
+  "css": {
+    "properties": {
+      "opacity": {
+        "__short_description": "The <strong><code>opacity</code></strong> CSS property sets the transparency of an element or the degree to which content behind an element is visible."
+      }
+    }
+  }
 }

--- a/descriptions/css/properties/opacity.json
+++ b/descriptions/css/properties/opacity.json
@@ -1,0 +1,3 @@
+{
+  "opacity": "The <strong><code>opacity</code></strong> CSS property sets the transparency of an element or the degree to which content behind an element is visible."
+}

--- a/descriptions/css/properties/padding-right.json
+++ b/descriptions/css/properties/padding-right.json
@@ -1,3 +1,9 @@
 {
-  "padding-right": "The<strong> <code>padding-right</code> </strong><a href='https://developer.mozilla.org/en/CSS'>CSS</a> property sets the width of the <a href='https://developer.mozilla.org/en/CSS/box_model#padding-area'>padding area</a> on the right side of an element."
+  "css": {
+    "properties": {
+      "padding-right": {
+        "__short_description": "The<strong> <code>padding-right</code> </strong><a href='https://developer.mozilla.org/en/CSS'>CSS</a> property sets the width of the <a href='https://developer.mozilla.org/en/CSS/box_model#padding-area'>padding area</a> on the right side of an element."
+      }
+    }
+  }
 }

--- a/descriptions/css/properties/padding-right.json
+++ b/descriptions/css/properties/padding-right.json
@@ -1,0 +1,3 @@
+{
+  "padding-right": "The<strong> <code>padding-right</code> </strong><a href='https://developer.mozilla.org/en/CSS'>CSS</a> property sets the width of the <a href='https://developer.mozilla.org/en/CSS/box_model#padding-area'>padding area</a> on the right side of an element."
+}

--- a/descriptions/css/properties/quotes.json
+++ b/descriptions/css/properties/quotes.json
@@ -1,3 +1,9 @@
 {
-  "quotes": "The <strong><code>quotes</code></strong> <a href='https://developer.mozilla.org/docs/CSS'>CSS</a> property sets how quotation marks appear."
+  "css": {
+    "properties": {
+      "quotes": {
+        "__short_description": "The <strong><code>quotes</code></strong> <a href='https://developer.mozilla.org/docs/CSS'>CSS</a> property sets how quotation marks appear."
+      }
+    }
+  }
 }

--- a/descriptions/css/properties/quotes.json
+++ b/descriptions/css/properties/quotes.json
@@ -1,0 +1,3 @@
+{
+  "quotes": "The <strong><code>quotes</code></strong> <a href='https://developer.mozilla.org/docs/CSS'>CSS</a> property sets how quotation marks appear."
+}


### PR DESCRIPTION
This PR adds a few JSON entries for short descriptions that I've revised. I figure we'll work out how we want to layout the descriptions by revising this PR.

My initial approach was to simply dump the short descriptions into JSON files named for each CSS property. This has the benefit of easy-to-follow diffs (i.e., the list of files modified tells you which properties changed), at the expense of more files and a bit of JSON noise. Plus it was easy to do this (I've got the start of a script to write out wiki short descriptions to JSON now).

Some other approaches I considered but didn't exactly reject that might be worth considering, however:

* using different keys (e.g., wiki page URLs instead of property names)
* adding additional data (e.g., wiki page URL, a last-scraped date, etc.)
* all properties in one JSON file (pro: fewer files; con: more complicated diffs)
* all properties in a plainer format such as a CSV file or in individual `.txt` files (pros: simpler format, less fuss with escaping stuff; con: harder to add additional data)

This is a step toward fulfilling #5.