### PR TITLE
Scrape wiki pages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,8 @@
 {
-    "extends": "airbnb-base"
+    "extends": "airbnb-base",
+    "root": true,
+    "rules": {
+        "no-console": "off",
+        "import/no-extraneous-dependencies": ["error", {"devDependencies": ["./test/*.js", "./scripts/*.js"]}]
+    }
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "request": "^2.88.0"
   },
   "scripts": {
+    "lint-js": "eslint test/*.js scripts/*.js",
     "lint-short-descriptions": "node test/lint-short-descriptions.js",
-    "lint-js": "npx eslint test/*.js"
+    "scrape": "node scripts/scrape.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/scrape.js
+++ b/scripts/scrape.js
@@ -36,7 +36,11 @@ const delocalize = (aElem) => {
   const a = aElem;
 
   if (a.hostname === 'developer.mozilla.org') {
-    a.href = a.href.replace(/[/]\w\w-\w\w(?=[/])/g, '');
+    const pathComponents = a.pathname.split('/');
+    if (pathComponents[1] !== 'docs') {
+      pathComponents.splice(1, 1);
+      a.pathname = pathComponents.join('/');
+    }
   }
 };
 

--- a/scripts/scrape.js
+++ b/scripts/scrape.js
@@ -94,8 +94,8 @@ const writeToFile = (propertyName, html) => {
   };
 
   const dest = path.join(__dirname, '../descriptions/css/properties/', `${propertyName}.json`);
-  fs.mkdirSync(path.dirname(dest), { recursive: true }, (err) => { if (err) throw err; });
-  fs.writeFile(dest, `${JSON.stringify(data, null, 2)}\n`, (err) => { if (err) throw err; });
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.writeFileSync(dest, `${JSON.stringify(data, null, 2)}\n`);
 };
 
 const main = (args) => {

--- a/scripts/scrape.js
+++ b/scripts/scrape.js
@@ -98,7 +98,10 @@ const writeToFile = (propertyName, html) => {
   };
 
   const dest = path.join(__dirname, '../descriptions/css/properties/', `${propertyName}.json`);
-  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  const destDir = path.dirname(dest);
+  if (!fs.existsSync(destDir)) {
+    fs.mkdirSync(path.dirname(destDir), { recursive: true });
+  }
   fs.writeFileSync(dest, `${JSON.stringify(data, null, 2)}\n`);
 };
 

--- a/scripts/scrape.js
+++ b/scripts/scrape.js
@@ -1,0 +1,128 @@
+// Examples:
+// Scrape the color property page summary on MDN Web Docs to JSON:
+//    $ npm run scrape color
+// Scrape the color and background-color property page summaries:
+//    $ npm run scrape color background-color
+// Scrape all the summaries for ALL the property pages known to mdn/data:
+//    $ npm run scrape
+
+const fs = require('fs');
+const path = require('path');
+
+const { properties } = require('mdn-data').css;
+const jsdom = require('jsdom');
+
+const allProperties = Object.keys(properties);
+
+const allowed = {
+  A: ['href'],
+  CODE: [],
+  EM: [],
+  STRONG: [],
+};
+
+// For limiting requests to the wiki, since it doesn't seem to like it when you make hundreds of
+// requests at once.
+const delay = timeout => new Promise(resolve => setTimeout(resolve, timeout));
+
+const summarize = (url) => {
+  // Add raw, summary, and cache-busting query parameters to a wiki page URL
+  const cacheBuster = Math.random().toString(36).substr(2, 5);
+  return `${url}?raw&summary&${cacheBuster}`;
+};
+
+const delocalize = (aElem) => {
+  // Remove the localization path from a wiki page URL (and only wiki page URLs)
+  const a = aElem;
+
+  if (a.hostname === 'developer.mozilla.org') {
+    a.href = a.href.replace(/[/]\w\w-\w\w(?=[/])/g, '');
+  }
+};
+
+const abs = (aElem) => {
+  // Make an A element's href attribute absolute
+  const a = aElem;
+
+  // An element's href property returns an absolute URL, but innerHTML seralizes a relative URL.
+  // The next line looks like it does nothing, but it replaces a relative URL with an absolute.
+  a.href = a.href;
+};
+
+const domTransforms = {
+  cleanLinks: (dom) => {
+    dom.window.document.querySelectorAll('BODY A').forEach((elem) => {
+      abs(elem);
+      delocalize(elem);
+    });
+
+    return dom;
+  },
+
+  stripUnwantedAttrs: (dom) => {
+    dom.window.document.querySelectorAll('BODY *').forEach((elem) => {
+      const allowedAttrs = allowed[elem.tagName];
+
+      if (allowedAttrs !== undefined) {
+        Array.from(elem.attributes).forEach((attr) => {
+          if (!allowedAttrs.includes(attr.name)) {
+            elem.removeAttribute(attr.name);
+          }
+        });
+      }
+    });
+    return dom;
+  },
+
+  toHTML: dom => dom.window.document.querySelector('BODY').innerHTML,
+};
+
+const htmlTransforms = {
+  replaceDoubleQuotes: html => html.replace(/"/g, "'"),
+  removeNbsps: html => html.replace(/&nbsp;/g, ' '),
+};
+
+const writeToFile = (propertyName, html) => {
+  const data = {
+    css: {
+      properties: {
+        [propertyName]: {
+          __short_description: html,
+        },
+      },
+    },
+  };
+
+  const dest = path.join(__dirname, '../descriptions/css/properties/', `${propertyName}.json`);
+  fs.mkdirSync(path.dirname(dest), { recursive: true }, (err) => { if (err) throw err; });
+  fs.writeFile(dest, `${JSON.stringify(data, null, 2)}\n`, (err) => { if (err) throw err; });
+};
+
+const main = (args) => {
+  const props = args.length === 0 ? allProperties : args;
+
+  props.forEach((propName, index) => {
+    const url = properties[propName].mdn_url;
+
+    if (url === undefined) {
+      console.warn(`WARNING: ${propName} has no \`mdn_url\` value. Skipping.`);
+      return;
+    }
+
+    delay(index * 500)
+      .then(() => jsdom.JSDOM.fromURL(summarize(url)))
+      .then(domTransforms.cleanLinks)
+      .then(domTransforms.stripUnwantedAttrs)
+      .then(domTransforms.toHTML)
+      .then(htmlTransforms.replaceDoubleQuotes)
+      .then(htmlTransforms.removeNbsps)
+      .then(html => writeToFile(propName, html))
+      .catch(console.trace);
+  });
+};
+
+const cli = () => {
+  main(process.argv.slice(2));
+};
+
+cli();

--- a/test/lint-short-descriptions.js
+++ b/test/lint-short-descriptions.js
@@ -8,8 +8,6 @@
 // Demo mode
 //    $ npm run lint-short-descriptions -- --self-test
 
-/* eslint-disable no-console */
-
 const readline = require('readline');
 
 const request = require('request');


### PR DESCRIPTION
OK, this ought to ingest some wiki page summaries and resolve #9.

Running `npm run scrape <property>` fetches a page from the wiki, such as https://developer.mozilla.org/docs/Web/CSS/animation-delay?raw&summary:

```html
The <strong><code>animation-delay</code></strong> <a href="/en-US/docs/CSS">CSS</a> property sets when an animation starts. The animation can start later, immediately from its beginning, or immediately and partway through the animation.
```

And writes out this:

```json
{
  "css": {
    "properties": {
      "animation-delay": {
        "__short_description": "The <strong><code>animation-delay</code></strong> <a href='https://developer.mozilla.org/docs/CSS'>CSS</a> property sets when an animation starts. The animation can start later, immediately from its beginning, or immediately and partway through the animation."
      }
    }
  }
}
```

A few additional notes:

* I changed the Airbnb eslint rules to be less annoying to our particular use. When time permits, I'll see about setting up Travis CI to run eslint on PRs.
* I've been staring at this a bit too long. I expect there are obvious bugs.

I'd welcome any and all comments. Thank you, @wbamberg!