### PR TITLE
Make it possible to require short-descriptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function collectJSON(directory) {
 }
 
 function loadJSON() {
-  const jsons = collectJSON('./descriptions');
+  const jsons = collectJSON(path.resolve(__dirname, './descriptions'));
   const finalObj = {};
 
   jsons.forEach((json) => {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-
 const extend = require('extend');
 
 function walk(directory, callback) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
+const extend = require('extend');
 const fs = require('fs');
 const path = require('path');
-const extend = require('extend');
 
 function walk(directory, callback) {
   fs.readdirSync(directory).forEach((filename) => {

--- a/index.js
+++ b/index.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+const extend = require('extend');
+
+function walk(directory, callback) {
+  fs.readdirSync(directory).forEach((filename) => {
+    const filepath = path.join(directory, filename);
+
+    if (fs.statSync(filepath).isDirectory()) {
+      walk(filepath, callback);
+    }
+    callback(filepath);
+  });
+}
+
+function collectJSON(directory) {
+  const filepaths = [];
+  walk(directory, (fp) => {
+    if (path.extname(fp) === '.json') {
+      filepaths.push(fp);
+    }
+  });
+  return filepaths;
+}
+
+function loadJSON() {
+  const jsons = collectJSON('./descriptions');
+  const finalObj = {};
+
+  jsons.forEach((json) => {
+    const nextObj = JSON.parse(fs.readFileSync(json, 'utf8'));
+    extend(true, finalObj, nextObj);
+  });
+  return finalObj;
+}
+
+module.exports = loadJSON();

--- a/package-lock.json
+++ b/package-lock.json
@@ -709,8 +709,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "external-editor": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "extend": "^3.0.2"
+  },
   "devDependencies": {
     "eslint": "^5.9.0",
     "eslint-config-airbnb-base": "^13.1.0",
@@ -16,7 +18,7 @@
     "request": "^2.88.0"
   },
   "scripts": {
-    "test": "npm run lint-js && node test/json-format-rules.js && node test/content-rules.js && npm run lint-json",
+    "test": "node test/test.js && npm run lint-js && node test/json-format-rules.js && node test/content-rules.js && npm run lint-json",
     "lint-js": "eslint test/*.js scripts/*.js",
     "lint-json": "node test/lint-json.js",
     "lint-wiki": "node test/lint-wiki.js",

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,8 @@
+/* eslint-disable no-underscore-dangle */
+const assert = require('assert');
+
+const descriptions = require('..');
+
+// Make sure the data is importable and does something vaguely useful
+assert(typeof descriptions.css.properties.opacity.__short_description === 'string');
+assert(descriptions.css.properties.opacity.__short_description.length > 0);


### PR DESCRIPTION
This PR adds an `index.js` file so you can properly `require` this package. It loads up the JSON files, compiles them into a single object, and exports that object. In other words, I'm totally copying after browser-compat-data.

~This PR will be a draft until #15 is merged, as my branch is based on that PR.~

Also, this PR is a major piece of #13.