### PR TITLE
Fix linter errors in current short descriptions

### DIFF
--- a/descriptions/css/properties/align-content.json
+++ b/descriptions/css/properties/align-content.json
@@ -2,7 +2,7 @@
   "css": {
     "properties": {
       "align-content": {
-        "__short_description": "The <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> <strong><code>align-content</code></strong> property sets how the browser distributes space between and around content items along the cross-axis of a <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_Flexible_Box_Layout'>flexbox</a> container, and the main-axis of a grid container."
+        "__short_description": "The <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> <strong><code>align-content</code></strong> property sets the distribution of space around content items of a <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_Flexible_Box_Layout'>flexbox</a> or <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout'>grid</a> container. It applies to a flexbox's cross-axis or a grid's tracks."
       }
     }
   }

--- a/descriptions/css/properties/align-content.json
+++ b/descriptions/css/properties/align-content.json
@@ -2,7 +2,7 @@
   "css": {
     "properties": {
       "align-content": {
-        "__short_description": "The <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> <strong><code>align-content</code></strong> property sets the distribution of space around content items of a <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_Flexible_Box_Layout'>flexbox</a> or <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout'>grid</a> container. It applies to a flexbox's cross-axis or a grid's tracks."
+        "__short_description": "The <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> <strong><code>align-content</code></strong> property sets the distribution of space between and around content items along a <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_Flexible_Box_Layout'>flexbox</a>'s cross-axis or a <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout'>grid</a>'s block axis."
       }
     }
   }


### PR DESCRIPTION
This PR fixes `align-content`'s linter errors, thus getting all of `npm test` to pass. This is a prerequisite to using Travis on this repo and a convenience for scraping more short descriptions.