### PR TITLE
Add 15 more standard, non-experimental descriptions (all through border)

### DIFF
--- a/descriptions/css/properties/all.json
+++ b/descriptions/css/properties/all.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "all": {
+        "__short_description": "The <code><strong>all</strong></code> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand property</a> resets all of an element's properties (except <a href='https://developer.mozilla.org/docs/Web/CSS/unicode-bidi'><code>unicode-bidi</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/direction'><code>direction</code></a>)."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/all.json
+++ b/descriptions/css/properties/all.json
@@ -2,7 +2,7 @@
   "css": {
     "properties": {
       "all": {
-        "__short_description": "The <code><strong>all</strong></code> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand property</a> resets all of an element's properties (except <a href='https://developer.mozilla.org/docs/Web/CSS/unicode-bidi'><code>unicode-bidi</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/direction'><code>direction</code></a>)."
+        "__short_description": "The <code><strong>all</strong></code> <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand</a> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property resets all of an element's properties (except <a href='https://developer.mozilla.org/docs/Web/CSS/unicode-bidi'><code>unicode-bidi</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/direction'><code>direction</code></a>)."
       }
     }
   }

--- a/descriptions/css/properties/animation-name.json
+++ b/descriptions/css/properties/animation-name.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "animation-name": {
+        "__short_description": "The <strong><code>animation-name</code></strong> <a href='https://developer.mozilla.org/docs/CSS'>CSS</a> property sets one or more animations to apply to an element. Each name is an <a href='https://developer.mozilla.org/docs/Web/CSS/@keyframes'><code>@keyframes</code></a> at-rule that sets the property values for the animation sequence."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/background-attachment.json
+++ b/descriptions/css/properties/background-attachment.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "background-attachment": {
+        "__short_description": "The <strong><code>background-attachment</code></strong> <a href='https://developer.mozilla.org/docs/CSS'>CSS</a> property sets whether a background image's position is fixed within the <a href='https://developer.mozilla.org/docs/Glossary/viewport'>viewport</a>, or scrolls with its containing block."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/background-clip.json
+++ b/descriptions/css/properties/background-clip.json
@@ -2,7 +2,7 @@
   "css": {
     "properties": {
       "background-clip": {
-        "__short_description": "The <strong><code>background-clip</code></strong> CSS property sets whether an element's background <a href='https://developer.mozilla.org/docs/Web/CSS/color_value'><code>&lt;color&gt;</code></a> or <a href='https://developer.mozilla.org/docs/Web/CSS/image'><code>&lt;image&gt;</code></a> extends underneath its border."
+        "__short_description": "The <strong><code>background-clip</code></strong> CSS property sets whether an element's background extends underneath its border box, padding box, or content box."
       }
     }
   }

--- a/descriptions/css/properties/background-clip.json
+++ b/descriptions/css/properties/background-clip.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "background-clip": {
+        "__short_description": "The <strong><code>background-clip</code></strong> CSS property sets whether an element's background <a href='https://developer.mozilla.org/docs/Web/CSS/color_value'><code>&lt;color&gt;</code></a> or <a href='https://developer.mozilla.org/docs/Web/CSS/image'><code>&lt;image&gt;</code></a> extends underneath its border."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/background-position-y.json
+++ b/descriptions/css/properties/background-position-y.json
@@ -2,7 +2,7 @@
   "css": {
     "properties": {
       "background-position-y": {
-        "__short_description": "The <strong><code>background-position-y</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the initial horizontal position for each background image. The position is relative to the position layer set by <a href='https://developer.mozilla.org/docs/Web/CSS/background-origin'><code>background-origin</code></a>."
+        "__short_description": "The <strong><code>background-position-y</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the initial vertical position for each background image. The position is relative to the position layer set by <a href='https://developer.mozilla.org/docs/Web/CSS/background-origin'><code>background-origin</code></a>."
       }
     }
   }

--- a/descriptions/css/properties/background-position-y.json
+++ b/descriptions/css/properties/background-position-y.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "background-position-y": {
+        "__short_description": "The <strong><code>background-position-y</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the initial horizontal position for each background image. The position is relative to the position layer set by <a href='https://developer.mozilla.org/docs/Web/CSS/background-origin'><code>background-origin</code></a>."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/background-position.json
+++ b/descriptions/css/properties/background-position.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "background-position": {
+        "__short_description": "The <strong><code>background-position</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the initial position for each background image. The position is relative to the position layer set by <a href='https://developer.mozilla.org/docs/Web/CSS/background-origin'><code>background-origin</code></a>."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/background.json
+++ b/descriptions/css/properties/background.json
@@ -2,7 +2,7 @@
   "css": {
     "properties": {
       "background": {
-        "__short_description": "The <strong><code>background</code></strong> shorthand <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets all background style properties at once, such as color, image, origin and size, or repeat method."
+        "__short_description": "The <strong><code>background</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand</a> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets all background style properties at once, such as color, image, origin and size, or repeat method."
       }
     }
   }

--- a/descriptions/css/properties/border-bottom.json
+++ b/descriptions/css/properties/border-bottom.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "border-bottom": {
+        "__short_description": "The <strong><code>border-bottom</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property is a shorthand that sets the values of <a href='https://developer.mozilla.org/docs/Web/CSS/border-bottom-width'><code>border-bottom-width</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/border-bottom-style'><code>border-bottom-style</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/border-bottom-color'><code>border-bottom-color</code></a>."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/border-bottom.json
+++ b/descriptions/css/properties/border-bottom.json
@@ -2,7 +2,7 @@
   "css": {
     "properties": {
       "border-bottom": {
-        "__short_description": "The <strong><code>border-bottom</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property is a shorthand that sets the values of <a href='https://developer.mozilla.org/docs/Web/CSS/border-bottom-width'><code>border-bottom-width</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/border-bottom-style'><code>border-bottom-style</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/border-bottom-color'><code>border-bottom-color</code></a>."
+        "__short_description": "The <strong><code>border-bottom</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand</a> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets an element's bottom <a href='https://developer.mozilla.org/docs/Web/CSS/border'>border</a>."
       }
     }
   }

--- a/descriptions/css/properties/border-color.json
+++ b/descriptions/css/properties/border-color.json
@@ -2,7 +2,7 @@
   "css": {
     "properties": {
       "border-color": {
-        "__short_description": "The <strong><code>border-color</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand</a> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the color an element's border."
+        "__short_description": "The <strong><code>border-color</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand</a> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the color of an element's border."
       }
     }
   }

--- a/descriptions/css/properties/border-color.json
+++ b/descriptions/css/properties/border-color.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "border-color": {
+        "__short_description": "The <strong><code>border-color</code></strong> shorthand <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the color of all sides of an element's border."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/border-color.json
+++ b/descriptions/css/properties/border-color.json
@@ -2,7 +2,7 @@
   "css": {
     "properties": {
       "border-color": {
-        "__short_description": "The <strong><code>border-color</code></strong> shorthand <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the color of all sides of an element's border."
+        "__short_description": "The <strong><code>border-color</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand</a> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the color an element's border."
       }
     }
   }

--- a/descriptions/css/properties/border-image-slice.json
+++ b/descriptions/css/properties/border-image-slice.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "border-image-slice": {
+        "__short_description": "The <strong><code>border-image-slice</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property divides the image specified by <a href='https://developer.mozilla.org/docs/Web/CSS/border-image-source'><code>border-image-source</code></a> into regions. These regions form the components of an element's <a href='https://developer.mozilla.org/docs/Web/CSS/border-image'>border image</a>."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/border-image.json
+++ b/descriptions/css/properties/border-image.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "border-image": {
+        "__short_description": "The <strong><code>border-image</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property draws an image in place of an element's <a href='https://developer.mozilla.org/docs/Web/CSS/border-style'><code>border-style</code></a>."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/border-left-style.json
+++ b/descriptions/css/properties/border-left-style.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "border-left-style": {
+        "__short_description": "The <strong><code>border-left-style</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the line style of an element's left <a href='https://developer.mozilla.org/docs/Web/CSS/border'><code>border</code></a>."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/border-right-color.json
+++ b/descriptions/css/properties/border-right-color.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "border-right-color": {
+        "__short_description": "The <strong><code>border-right-color</code></strong> CSS property sets the color of an element's right <a href='https://developer.mozilla.org/docs/Web/CSS/border'>border</a>. It can also be set with the shorthand CSS properties <a href='https://developer.mozilla.org/docs/Web/CSS/border-color'><code>border-color</code></a> or <a href='https://developer.mozilla.org/docs/Web/CSS/border-right'><code>border-right</code></a>."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/border-right-style.json
+++ b/descriptions/css/properties/border-right-style.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "border-right-style": {
+        "__short_description": "The <strong><code>border-right-style</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the line style of an element's right <a href='https://developer.mozilla.org/docs/Web/CSS/border'><code>border</code></a>."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/border-right.json
+++ b/descriptions/css/properties/border-right.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "border-right": {
+        "__short_description": "The <strong><code>border-right</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property is a shorthand that sets the values of <a href='https://developer.mozilla.org/docs/Web/CSS/border-right-width'><code>border-right-width</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/border-right-style'><code>border-right-style</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/border-right-color'><code>border-right-color</code></a>."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/border-right.json
+++ b/descriptions/css/properties/border-right.json
@@ -2,7 +2,7 @@
   "css": {
     "properties": {
       "border-right": {
-        "__short_description": "The <strong><code>border-right</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property is a shorthand that sets the values of <a href='https://developer.mozilla.org/docs/Web/CSS/border-right-width'><code>border-right-width</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/border-right-style'><code>border-right-style</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/border-right-color'><code>border-right-color</code></a>."
+        "__short_description": "The <strong><code>border-right</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand</a> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets an element's right <a href='https://developer.mozilla.org/docs/Web/CSS/border'>border</a>."
       }
     }
   }

--- a/descriptions/css/properties/border.json
+++ b/descriptions/css/properties/border.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "border": {
+        "__short_description": "The <strong><code>border</code></strong> <a href='https://developer.mozilla.org/docs/CSS'>CSS</a> property sets an element's border. It's a <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand</a> for <a href='https://developer.mozilla.org/docs/Web/CSS/border-width'><code>border-width</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/border-style'><code>border-style</code></a>, and <a href='https://developer.mozilla.org/docs/Web/CSS/border-color'><code>border-color</code></a>."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/border.json
+++ b/descriptions/css/properties/border.json
@@ -2,7 +2,7 @@
   "css": {
     "properties": {
       "border": {
-        "__short_description": "The <strong><code>border</code></strong> <a href='https://developer.mozilla.org/docs/CSS'>CSS</a> property sets an element's border. It's a <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand</a> for <a href='https://developer.mozilla.org/docs/Web/CSS/border-width'><code>border-width</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/border-style'><code>border-style</code></a>, and <a href='https://developer.mozilla.org/docs/Web/CSS/border-color'><code>border-color</code></a>."
+        "__short_description": "The <strong><code>border</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand</a> <a href='https://developer.mozilla.org/docs/CSS'>CSS</a> property sets an element's border."
       }
     }
   }


### PR DESCRIPTION
This adds 15 more short descriptions. Sorry for the weird sequence with respect to #22—something was off in the way my spreadsheet was filtering properties yesterday.

1. https://developer.mozilla.org/docs/Web/CSS/all
1. https://developer.mozilla.org/docs/Web/CSS/animation-name
1. https://developer.mozilla.org/docs/Web/CSS/background-attachment
1. https://developer.mozilla.org/docs/Web/CSS/background-clip
1. https://developer.mozilla.org/docs/Web/CSS/background-position-y
1. https://developer.mozilla.org/docs/Web/CSS/background-position
1. https://developer.mozilla.org/docs/Web/CSS/border-bottom
1. https://developer.mozilla.org/docs/Web/CSS/border-color
1. https://developer.mozilla.org/docs/Web/CSS/border-image-slice
1. https://developer.mozilla.org/docs/Web/CSS/border-image
1. https://developer.mozilla.org/docs/Web/CSS/border-left-style
1. https://developer.mozilla.org/docs/Web/CSS/border-right-color
1. https://developer.mozilla.org/docs/Web/CSS/border-right-style
1. https://developer.mozilla.org/docs/Web/CSS/border-right
1. https://developer.mozilla.org/docs/Web/CSS/border