### PR TITLE
Use shorthand text and link consistently

### DIFF
--- a/descriptions/css/properties/background.json
+++ b/descriptions/css/properties/background.json
@@ -2,7 +2,7 @@
   "css": {
     "properties": {
       "background": {
-        "__short_description": "The <strong><code>background</code></strong> shorthand <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets all background style properties at once, such as color, image, origin and size, or repeat method."
+        "__short_description": "The <strong><code>background</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand</a> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets all background style properties at once, such as color, image, origin and size, or repeat method."
       }
     }
   }


### PR DESCRIPTION
From a comment on #22, I decided to make sure the phrase "shorthand CSS property" phrase was used consistently. Since all the others use a link, this one needs a link too.