### PR TITLE
Add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+node_js: stable
+sudo: false
+notifications:
+  email: false
+script:
+  - npm test
+  - bash test/test-built-package.sh
+deploy:
+  provider: npm
+  email: mdn-npm@mozilla.com
+  api_key: $NPM_TOKEN
+  on:
+    tags: true
+    repo: mdn/short-descriptions

--- a/publishing-the-package.md
+++ b/publishing-the-package.md
@@ -1,0 +1,1 @@
+# Publishing mdn-short-descriptions on npm

--- a/test/test-built-package.sh
+++ b/test/test-built-package.sh
@@ -1,0 +1,21 @@
+set -e
+
+# Validate that this package can be installed and it contains some data
+
+STARTING_DIR="$(pwd)"
+
+npm pack
+echo
+echo '✅ Package built!'
+echo
+
+cd "$(mktemp -d)"
+cp $STARTING_DIR/*.tgz .
+npm init --yes
+npm install *.tgz
+echo '✅ Package installed!'
+echo
+
+node -e 'typeof require("mdn-short-descriptions").css.properties.background.__short_description == "string" || process.exit(1)'
+echo '🏁 Package contained some data! 🏁'
+echo


### PR DESCRIPTION
This is a first step to resolving #21 and shipping a package.

This PR adds a Travis CI file that builds the package, runs the tests, and then verifies that the package can be installed (as we talked about on #17). It will also publish tags to npm (à la browser-compat-data).

There's a couple hitches here, though: this is missing documentation and I don't have admin rights on this repo, so I don't know if Travis CI is turned on or if the appropriate npm token is already set up. Thus the draft status.

I'd welcome some input on the next steps on the admin-y part of this, Will! Thank you!