### PR TITLE
Add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+node_js: stable
+sudo: false
+notifications:
+  email: false
+script:
+  - npm test
+  - bash test/test-built-package.sh
+deploy:
+  provider: npm
+  email: mdn-npm@mozilla.com
+  api_key: $NPM_TOKEN
+  on:
+    tags: true
+    repo: mdn/short-descriptions

--- a/publishing-the-package.md
+++ b/publishing-the-package.md
@@ -1,1 +1,11 @@
 # Publishing mdn-short-descriptions on npm
+
+Project owners can publish mdn-short-descriptions on npm by following these steps:
+
+1. Figure out the next version number by looking at [past releases](https://github.com/mdn/short-descriptions/releases). The project is in alpha, so we're using only patch versions.
+2. On an updated and clean master branch, `run npm version patch -m "Nth alpha version"`. Locally, this updates `package.json`, creates a new commit, and creates a new release tag (see the docs for [npm version](https://docs.npmjs.com/cli/version)).
+3. Push the commit to master: `git push origin master`.
+4. Check if the commit passes on [Travis CI](https://travis-ci.org/mdn/short-descriptions).
+5. If Travis passes, push the git tag: `git push origin v0.0.X`. This step will trigger Travis to publish to npm automatically (see our [.travis.yml file](https://github.com/mdn/short-descriptions/blob/master/.travis.yml)).
+6. Check [Travis CI](https://travis-ci.org/mdn/short-descriptions) again for the tag build and also check [mdn-short-descriptions on npm](https://www.npmjs.com/package/mdn-short-descriptions) to see if the release shows up correctly once Travis has finished its work.
+7. Create a new [release on GitHub](https://github.com/mdn/short-descriptions/releases) and document changes.

--- a/publishing-the-package.md
+++ b/publishing-the-package.md
@@ -1,0 +1,1 @@
+# Publishing mdn-short-descriptions on npm

--- a/test/test-built-package.sh
+++ b/test/test-built-package.sh
@@ -1,0 +1,21 @@
+set -e
+
+# Validate that this package can be installed and it contains some data
+
+STARTING_DIR="$(pwd)"
+
+npm pack
+echo
+echo '✅ Package built!'
+echo
+
+cd "$(mktemp -d)"
+cp $STARTING_DIR/*.tgz .
+npm init --yes
+npm install *.tgz
+echo '✅ Package installed!'
+echo
+
+node -e 'typeof require("mdn-short-descriptions").css.properties.background.__short_description == "string" || process.exit(1)'
+echo '🏁 Package contained some data! 🏁'
+echo


### PR DESCRIPTION
(This supersedes #25.)

This is a first step to resolving #21 and shipping a package.

This PR adds a Travis CI file that builds the package, runs the tests, and then verifies that the package can be installed (as we talked about on #17). It will also publish tags to npm (à la browser-compat-data).

~This is in draft status to test whether it works. It still needs docs.~