### PR TITLE
Add 15 descriptions: border-style through caret-color

### DIFF
--- a/descriptions/css/properties/border-style.json
+++ b/descriptions/css/properties/border-style.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "border-style": {
+        "__short_description": "The <strong><code>border-style</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand</a> <a href='https://developer.mozilla.org/CSS'>CSS</a> property sets the line style for all four sides of an element's border."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/border-top-color.json
+++ b/descriptions/css/properties/border-top-color.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "border-top-color": {
+        "__short_description": "The <strong><code>border-top-color</code></strong> CSS property sets the color of an element's top <a href='https://developer.mozilla.org/docs/Web/CSS/border'>border</a>."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/border-top-left-radius.json
+++ b/descriptions/css/properties/border-top-left-radius.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "border-top-left-radius": {
+        "__short_description": "The <strong><code>border-top-left-radius</code></strong> CSS property rounds the top-left corner of an element."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/border-top-right-radius.json
+++ b/descriptions/css/properties/border-top-right-radius.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "border-top-right-radius": {
+        "__short_description": "The <strong><code>border-top-right-radius</code></strong> CSS property rounds the top-right corner of an element."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/border-top-width.json
+++ b/descriptions/css/properties/border-top-width.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "border-top-width": {
+        "__short_description": "The <strong><code>border-top-width</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the width of the top border of an element."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/border-top.json
+++ b/descriptions/css/properties/border-top.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "border-top": {
+        "__short_description": "The <strong><code>border-top</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand</a> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property set an element's top <a href='https://developer.mozilla.org/docs/Web/CSS/border'>border</a>."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/border-width.json
+++ b/descriptions/css/properties/border-width.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "border-width": {
+        "__short_description": "The <strong><code>border-width</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand</a> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the width of an element's border."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/bottom.json
+++ b/descriptions/css/properties/bottom.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "bottom": {
+        "__short_description": "The <strong><code>bottom</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property participates in setting the vertical position of a <a href='https://developer.mozilla.org/docs/Web/CSS/position'>positioned element</a>. It has no effect on non-positioned elements."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/box-shadow.json
+++ b/descriptions/css/properties/box-shadow.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "box-shadow": {
+        "__short_description": "The <strong><code>box-shadow</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property adds shadow effects around an element's frame. You can set multiple effects separated by commas."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/box-sizing.json
+++ b/descriptions/css/properties/box-sizing.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "box-sizing": {
+        "__short_description": "The <strong><code>box-sizing</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets how the total width and height of an element is calculated."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/break-after.json
+++ b/descriptions/css/properties/break-after.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "break-after": {
+        "__short_description": "The <strong><code>break-after</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets how page, column, or region breaks should behave after a generated box. If there is no generated box, the property is ignored."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/break-before.json
+++ b/descriptions/css/properties/break-before.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "break-before": {
+        "__short_description": "The <strong><code>break-before</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets how page, column, or region breaks should behave before a generated box. If there is no generated box, the property is ignored."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/break-inside.json
+++ b/descriptions/css/properties/break-inside.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "break-inside": {
+        "__short_description": "The <strong><code>break-inside</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets how page, column, or region breaks should behave inside a generated box. If there is no generated box, the property is ignored."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/caption-side.json
+++ b/descriptions/css/properties/caption-side.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "caption-side": {
+        "__short_description": "The <strong><code>caption-side</code></strong> <a href='https://developer.mozilla.org/CSS'>CSS</a> property puts the content of a table's <a href='https://developer.mozilla.org/docs/Web/HTML/Element/caption'><code>&lt;caption&gt;</code></a> on the specified side. The values are relative to the <a href='https://developer.mozilla.org/docs/Web/CSS/writing-mode'><code>writing-mode</code></a> of the table."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/caret-color.json
+++ b/descriptions/css/properties/caret-color.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "caret-color": {
+        "__short_description": "The <strong><code>caret-color</code></strong> CSS property sets the color of the insertion caret, the visible marker where the next character typed will be inserted."
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds:

1. https://developer.mozilla.org/docs/Web/CSS/border-style
1. https://developer.mozilla.org/docs/Web/CSS/border-top
1. https://developer.mozilla.org/docs/Web/CSS/border-top-color
1. https://developer.mozilla.org/docs/Web/CSS/border-top-left-radius
1. https://developer.mozilla.org/docs/Web/CSS/border-top-right-radius
1. https://developer.mozilla.org/docs/Web/CSS/border-top-width
1. https://developer.mozilla.org/docs/Web/CSS/border-width
1. https://developer.mozilla.org/docs/Web/CSS/bottom
1. https://developer.mozilla.org/docs/Web/CSS/box-shadow
1. https://developer.mozilla.org/docs/Web/CSS/box-sizing
1. https://developer.mozilla.org/docs/Web/CSS/break-after
1. https://developer.mozilla.org/docs/Web/CSS/break-before
1. https://developer.mozilla.org/docs/Web/CSS/break-inside
1. https://developer.mozilla.org/docs/Web/CSS/caption-side
1. https://developer.mozilla.org/docs/Web/CSS/caret-color