### PR TITLE
Add high-priority CSS properties

### DIFF
--- a/descriptions/css/properties/background-image.json
+++ b/descriptions/css/properties/background-image.json
@@ -2,7 +2,7 @@
   "css": {
     "properties": {
       "background-image": {
-        "__short_description": "The <strong><code>background-image</code></strong> <a href='https://developer.mozilla.org/docs/CSS'>CSS</a> property sets one or more background images on an element."
+        "__short_description": "The <strong><code>background-image</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets one or more background images on an element."
       }
     }
   }

--- a/descriptions/css/properties/cursor.json
+++ b/descriptions/css/properties/cursor.json
@@ -2,7 +2,7 @@
   "css": {
     "properties": {
       "cursor": {
-        "__short_description": "The <strong><code>cursor</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the cursor to show when the mouse pointer is over an element."
+        "__short_description": "The <strong><code>cursor</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the type of cursor, if any, to show when the mouse pointer is over an element."
       }
     }
   }

--- a/descriptions/css/properties/cursor.json
+++ b/descriptions/css/properties/cursor.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "cursor": {
+        "__short_description": "The <strong><code>cursor</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the cursor to show when the mouse pointer is over an element."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/display.json
+++ b/descriptions/css/properties/display.json
@@ -2,7 +2,7 @@
   "css": {
     "properties": {
       "display": {
-        "__short_description": "The <strong><code>display</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets an element's inner and outer display types. The outer type sets an element's participation in <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_Flow_Layout'>flow layout</a>; the inner type sets the layout of children."
+        "__short_description": "The <strong><code>display</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets whether an element is treated as a <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_Flow_Layout'>block or inline element</a> and the layout used for its children, such as <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout'>grid</a> or <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_Flexible_Box_Layout'>flex</a>."
       }
     }
   }

--- a/descriptions/css/properties/display.json
+++ b/descriptions/css/properties/display.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "display": {
+        "__short_description": "The <strong><code>display</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets an element's inner and outer display types. The outer type sets an element's participation in <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_Flow_Layout'>flow layout</a>; the inner type sets the layout of children."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/flex.json
+++ b/descriptions/css/properties/flex.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "flex": {
+        "__short_description": "The <strong><code>flex</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets how a flex item will grow or shrink to fit the space available in its flex container."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/font-size.json
+++ b/descriptions/css/properties/font-size.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "font-size": {
+        "__short_description": "The <strong><code>font-size</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the size of the font."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/font-weight.json
+++ b/descriptions/css/properties/font-weight.json
@@ -2,7 +2,7 @@
   "css": {
     "properties": {
       "font-weight": {
-        "__short_description": "The <strong><code>font-weight</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the weight (or boldness) of the font. The weights available depend on the <a href='https://developer.mozilla.org/docs/Web/CSS/font-family'><code>font-family</code></a> you are using. Some are only available in <code>normal</code> and <code>bold</code>."
+        "__short_description": "The <strong><code>font-weight</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the weight (or boldness) of the font. The weights available depend on the <a href='https://developer.mozilla.org/docs/Web/CSS/font-family'><code>font-family</code></a> you are using."
       }
     }
   }

--- a/descriptions/css/properties/font-weight.json
+++ b/descriptions/css/properties/font-weight.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "font-weight": {
+        "__short_description": "The <strong><code>font-weight</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the weight (or boldness) of the font. The weights available depend on the <a href='https://developer.mozilla.org/docs/Web/CSS/font-family'><code>font-family</code></a> you are using. Some are only available in <code>normal</code> and <code>bold</code>."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/line-height.json
+++ b/descriptions/css/properties/line-height.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "line-height": {
+        "__short_description": "The <strong><code>line-height</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the amount of space used for lines, such as in text."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/line-height.json
+++ b/descriptions/css/properties/line-height.json
@@ -2,7 +2,7 @@
   "css": {
     "properties": {
       "line-height": {
-        "__short_description": "The <strong><code>line-height</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the amount of space used for lines, such as in text."
+        "__short_description": "The <strong><code>line-height</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the height of a line box. It's commonly used to set the distance between lines of text."
       }
     }
   }

--- a/descriptions/css/properties/overflow.json
+++ b/descriptions/css/properties/overflow.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "overflow": {
+        "__short_description": "The <strong><code>overflow</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand</a> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets what to do when an element's content is too big to fit in its <a href='https://developer.mozilla.org/docs/CSS/block_formatting_context'>block formatting context</a>."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/pointer-events.json
+++ b/descriptions/css/properties/pointer-events.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "pointer-events": {
+        "__short_description": "The <strong> <code>pointer-events</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets under what circumstances (if any) a particular graphic element can become the <a href='https://developer.mozilla.org/docs/Web/API/Event/target'>target</a> of pointer events."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/position.json
+++ b/descriptions/css/properties/position.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "position": {
+        "__short_description": "The <strong><code>position</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets how an element is positioned in a document. The <a href='https://developer.mozilla.org/docs/Web/CSS/top'><code>top</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/right'><code>right</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/bottom'><code>bottom</code></a>, and <a href='https://developer.mozilla.org/docs/Web/CSS/left'><code>left</code></a> properties determine the final location of positioned elements."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/text-decoration.json
+++ b/descriptions/css/properties/text-decoration.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "text-decoration": {
+        "__short_description": "The <strong><code>text-decoration</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand</a> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the appearance of decorative lines on text."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/text-overflow.json
+++ b/descriptions/css/properties/text-overflow.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "text-overflow": {
+        "__short_description": "The <strong><code>text-overflow</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets how hidden overflow content is signaled to users. It can be clipped, display an ellipsis ('<code>…</code>'), or display a custom string."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/transform.json
+++ b/descriptions/css/properties/transform.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "transform": {
+        "__short_description": "The <strong><code>transform</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property lets you rotate, scale, skew, or translate an element. It modifies the coordinate space of the CSS <a href='https://developer.mozilla.org/docs/Web/CSS/Visual_formatting_model'>visual formatting model</a>."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/vertical-align.json
+++ b/descriptions/css/properties/vertical-align.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "vertical-align": {
+        "__short_description": "The <strong><code>vertical-align</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets vertical alignment of an inline or table-cell box."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/z-index.json
+++ b/descriptions/css/properties/z-index.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "z-index": {
+        "__short_description": "The <strong><code>z-index</code></strong> CSS property sets the z-order of a <a href='https://developer.mozilla.org/docs/Web/CSS/position'>positioned</a> element and its descendants or flex items. Overlapping elements with a larger z-index cover those with a smaller one."
+      }
+    }
+  }
+}


### PR DESCRIPTION
I'm breaking the mold here from adding properties alphabetically. This PR (re)scrapes the 15 highest priority properties not already scraped, as reported by @chrisdavidmills's docs maintenance spreadsheet. I figured our first release ought to cover the most interesting properties, so I wanted to get these in sooner rather than later.

1. https://developer.mozilla.org/docs/Web/CSS/background-image
1. https://developer.mozilla.org/docs/Web/CSS/cursor
1. https://developer.mozilla.org/docs/Web/CSS/display
1. https://developer.mozilla.org/docs/Web/CSS/flex
1. https://developer.mozilla.org/docs/Web/CSS/font-size
1. https://developer.mozilla.org/docs/Web/CSS/font-weight
1. https://developer.mozilla.org/docs/Web/CSS/line-height
1. https://developer.mozilla.org/docs/Web/CSS/overflow
1. https://developer.mozilla.org/docs/Web/CSS/pointer-events
1. https://developer.mozilla.org/docs/Web/CSS/position
1. https://developer.mozilla.org/docs/Web/CSS/text-decoration
1. https://developer.mozilla.org/docs/Web/CSS/text-overflow
1. https://developer.mozilla.org/docs/Web/CSS/transform
1. https://developer.mozilla.org/docs/Web/CSS/vertical-align
1. https://developer.mozilla.org/docs/Web/CSS/z-index