### PR TITLE
Add 15 CSS properties: clear through direction

### DIFF
--- a/descriptions/css/properties/clear.json
+++ b/descriptions/css/properties/clear.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "clear": {
+        "__short_description": "The <strong><code>clear</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets whether an element must be moved below (cleared) <a href='https://developer.mozilla.org/docs/Web/CSS/float'>floating</a> elements that precede it. The <code>clear</code> property applies to floating and non-floating elements."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/clip-path.json
+++ b/descriptions/css/properties/clip-path.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "clip-path": {
+        "__short_description": "The <code><strong>clip-path</strong></code> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property creates a clipping region that sets what part of an element should be shown. Parts that are inside the region are shown, while those outside are hidden."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/color.json
+++ b/descriptions/css/properties/color.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "color": {
+        "__short_description": "The <strong><code>color</code></strong> CSS property sets the foreground <a href='https://developer.mozilla.org/docs/Web/CSS/color_value'>color value</a> of an element's text and <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration'>text decorations</a>, and sets the <a href='https://developer.mozilla.org/docs/Web/CSS/currentcolor'><code>currentcolor</code></a> value."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/column-count.json
+++ b/descriptions/css/properties/column-count.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "column-count": {
+        "__short_description": "The <strong><code>column-count</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property breaks an element's content into the specified number of columns."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/column-fill.json
+++ b/descriptions/css/properties/column-fill.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "column-fill": {
+        "__short_description": "The <strong><code>column-fill</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property controls how an element's contents are balanced when broken into columns."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/column-rule-color.json
+++ b/descriptions/css/properties/column-rule-color.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "column-rule-color": {
+        "__short_description": "The<strong> <code>column-rule-color</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the color of the line drawn between columns in a multi-column layout."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/column-rule-style.json
+++ b/descriptions/css/properties/column-rule-style.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "column-rule-style": {
+        "__short_description": "The <strong><code>column-rule-style</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the style of the line drawn between columns in a multi-column layout."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/column-rule-width.json
+++ b/descriptions/css/properties/column-rule-width.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "column-rule-width": {
+        "__short_description": "The <strong><code>column-rule-width</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the width of the line drawn between columns in a multi-column layout."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/column-rule.json
+++ b/descriptions/css/properties/column-rule.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "column-rule": {
+        "__short_description": "The <strong><code>column-rule</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS/Shorthand_properties'>shorthand</a> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the width, style, and color of the line drawn between columns in a multi-column layout."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/column-span.json
+++ b/descriptions/css/properties/column-span.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "column-span": {
+        "__short_description": "The <strong><code>column-span</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property makes it possible for an element to span across all columns when its value is set to <code>all</code>."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/column-width.json
+++ b/descriptions/css/properties/column-width.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "column-width": {
+        "__short_description": "The <strong><code>column-width</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property sets the ideal column width in a multi-column layout."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/content.json
+++ b/descriptions/css/properties/content.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "content": {
+        "__short_description": "The <strong><code>content</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property replaces an element with a generated value. Objects inserted using the <code>content</code> property are <em>anonymous <a href='https://developer.mozilla.org/docs/Web/CSS/Replaced_element'>replaced elements</a>.</em>"
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/counter-increment.json
+++ b/descriptions/css/properties/counter-increment.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "counter-increment": {
+        "__short_description": "The <strong><code>counter-increment</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property increases or decreases the value of a <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_Lists_and_Counters/Using_CSS_counters'>CSS counter</a> by a given value."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/counter-reset.json
+++ b/descriptions/css/properties/counter-reset.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "counter-reset": {
+        "__short_description": "The <strong><code>counter-reset</code></strong> <a href='https://developer.mozilla.org/docs/Web/CSS'>CSS</a> property resets a <a href='https://developer.mozilla.org/docs/Web/Guide/CSS/Counters'>CSS counter</a> to a given value."
+      }
+    }
+  }
+}

--- a/descriptions/css/properties/direction.json
+++ b/descriptions/css/properties/direction.json
@@ -1,0 +1,9 @@
+{
+  "css": {
+    "properties": {
+      "direction": {
+        "__short_description": "The <strong><code>direction</code></strong> CSS property sets the direction of text, table columns, and horizontal overflow."
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds fifteen more short descriptions, for the following properties. Let me know what you think, @wbamberg, but no pressure on this (I think I we agreed to decommit to getting many or any of these done during this sprint).

1. [`clear`](https://developer.mozilla.org/en-US/docs/Web/CSS/clear)
1. [`clip-path`](https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path)
1. [`color`](https://developer.mozilla.org/en-US/docs/Web/CSS/color)
1. [`column-count`](https://developer.mozilla.org/en-US/docs/Web/CSS/column-count)
1. [`column-fill`](https://developer.mozilla.org/en-US/docs/Web/CSS/column-fill)
1. [`column-rule`](https://developer.mozilla.org/en-US/docs/Web/CSS/column-rule)
1. [`column-rule-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/column-rule-color)
1. [`column-rule-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/column-rule-style)
1. [`column-rule-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/column-rule-width)
1. [`column-span`](https://developer.mozilla.org/en-US/docs/Web/CSS/column-span)
1. [`column-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/column-width)
1. [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content)
1. [`counter-increment`](https://developer.mozilla.org/en-US/docs/Web/CSS/counter-increment)
1. [`counter-reset`](https://developer.mozilla.org/en-US/docs/Web/CSS/counter-reset)
1. [`direction`](https://developer.mozilla.org/en-US/docs/Web/CSS/direction)

Toward #14.